### PR TITLE
disabling gpu in chromium seems to fix pdf generation that hangs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV PUPPETEER_SKIP_DOWNLOAD true
 ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium-browser
 
 # Need to run Chromium with --no-sandbox since GitHub Actions run as root
-ENV CHROMIUM_USER_FLAGS "--no-sandbox"
+ENV CHROMIUM_USER_FLAGS "--no-sandbox --disable-gpu"
 
 # Install C4Builder
 RUN npm install --global c4builder


### PR DESCRIPTION
The C4Builder hangs during the PDF generation stage. This is connected to a node library using chromium for the PDF generation. Searching the Internet for people with similar problems led to advice on disabling GPU usage in chromium and that solved the problem. I have no deeper knowledge or understanding of but running chromium like this inside my local docker images with the GPU disabled stopped it from hanging.